### PR TITLE
Removes createJSModules annotation due to non-support in 0.47

### DIFF
--- a/android/src/main/java/com/pomocorp/rnimagetools/RNImageToolsPackage.java
+++ b/android/src/main/java/com/pomocorp/rnimagetools/RNImageToolsPackage.java
@@ -17,11 +17,6 @@ public class RNImageToolsPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/pomocorp/rnimagetools/RNImageToolsPackage.java
+++ b/android/src/main/java/com/pomocorp/rnimagetools/RNImageToolsPackage.java
@@ -16,6 +16,10 @@ public class RNImageToolsPackage implements ReactPackage {
         return Arrays.<NativeModule>asList(new RNImageToolsModule(reactContext));
     }
 
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return Collections.emptyList();
+    }
+
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();


### PR DESCRIPTION
0.47 removes the createJSModules annotation.